### PR TITLE
Support modern pip using pip-shims

### DIFF
--- a/landinggear/base.py
+++ b/landinggear/base.py
@@ -2,8 +2,8 @@ from __future__ import absolute_import, print_function
 
 import os.path
 
-from pip.locations import USER_CACHE_DIR
-from pip.utils import normalize_path
+from pip_shims import USER_CACHE_DIR
+from vistir.path import normalize_path
 
 
 class LandingGearError(Exception):

--- a/landinggear/httpcache.py
+++ b/landinggear/httpcache.py
@@ -4,7 +4,8 @@ import os
 import os.path
 from zipfile import BadZipfile, ZipFile
 
-from pip.download import CacheControlAdapter, SafeFileCache
+from cachecontrol import CacheControlAdapter
+from pip_shims import SafeFileCache
 from wheel.pkginfo import read_pkg_info_bytes
 
 from landinggear.base import CachedPackage, CacheExtractor, pip_cache_subdir

--- a/landinggear/tests/test_wheelcache.py
+++ b/landinggear/tests/test_wheelcache.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, print_function
 import os.path
 from unittest import TestCase
 
-from pip.locations import USER_CACHE_DIR
+from pip_shims import USER_CACHE_DIR
 
 from landinggear.base import LandingGearError
 from landinggear.tests.helpers import tempcache, tempdir

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     license="MIT",
     keywords=["pip", "wheel", "aeroplane", "cache"],
     url="https://github.com/jerith/landinggear",
-    install_requires=["pip", "wheel"],
+    install_requires=["pip", "wheel", "CacheControl", "pip-shims", "vistir"],
     packages=find_packages(),
     include_package_data=True,
     entry_points={

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = py27,py35,pypy
 
 [testenv]
 deps =
+    colorama<=0.4.1
     pytest
     pytest-flake8
 commands = py.test --flake8


### PR DESCRIPTION
Also CacheControl and vistir are used to replace pip internals.

Fixes https://github.com/jerith/landinggear/issues/1